### PR TITLE
Fixed case in classes and method names

### DIFF
--- a/source/administrator/components/com_jedchecker/controller.php
+++ b/source/administrator/components/com_jedchecker/controller.php
@@ -14,6 +14,6 @@ defined('_JEXEC') or die ('Restricted access');
  *
  * @since  1.0
  */
-class JedcheckerController extends JControllerlegacy
+class JedcheckerController extends JControllerLegacy
 {
 }

--- a/source/administrator/components/com_jedchecker/controllers/police.raw.php
+++ b/source/administrator/components/com_jedchecker/controllers/police.raw.php
@@ -19,7 +19,7 @@ jimport('joomla.filesystem.archive');
  *
  * @since  1.0
  */
-class JedcheckerControllerPolice extends JControllerlegacy
+class JedcheckerControllerPolice extends JControllerLegacy
 {
 	/**
 	 * Runs all the rules on the given directory

--- a/source/administrator/components/com_jedchecker/controllers/uploads.php
+++ b/source/administrator/components/com_jedchecker/controllers/uploads.php
@@ -18,7 +18,7 @@ jimport('joomla.filesystem.archive');
  *
  * @since  1.0
  */
-class JedcheckerControllerUploads extends JControllerlegacy
+class JedcheckerControllerUploads extends JControllerLegacy
 {
 	/**
 	 * Constructor.

--- a/source/administrator/components/com_jedchecker/libraries/rules/xmlinfo.php
+++ b/source/administrator/components/com_jedchecker/libraries/rules/xmlinfo.php
@@ -71,7 +71,7 @@ class JedcheckerRulesXMLinfo extends JEDcheckerRule
 	 */
 	protected function find($file)
 	{
-		$xml = JFactory::getXML($file);
+		$xml = JFactory::getXml($file);
 
 		// Failed to parse the xml file.
 		// Assume that this is not a extension manifest

--- a/source/administrator/components/com_jedchecker/libraries/rules/xmllicense.php
+++ b/source/administrator/components/com_jedchecker/libraries/rules/xmllicense.php
@@ -69,7 +69,7 @@ class JedcheckerRulesXMLlicense extends JEDcheckerRule
 	 */
 	protected function find($file)
 	{
-		$xml = JFactory::getXML($file);
+		$xml = JFactory::getXml($file);
 
 		// Failed to parse the xml file.
 		// Assume that this is not a extension manifest

--- a/source/administrator/components/com_jedchecker/views/uploads/tmpl/default.php
+++ b/source/administrator/components/com_jedchecker/views/uploads/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die('Restricted access');
 
-JHTML::_('behavior.framework', true);
+JHtml::_('behavior.framework', true);
 JHtml::_('behavior.formvalidation');
 JHtml::_('behavior.keepalive');
 JHtml::stylesheet('media/com_jedchecker/css/css.css');
@@ -53,7 +53,7 @@ JHtml::script('media/com_jedchecker/js/police.js');
 					<span class="icon-upload "></span> <?php echo JText::_('JSUBMIT'); ?>
 				</button>
 				<input type="hidden" name="task" value=""/>
-				<?php echo JHTML::_('form.token'); ?>
+				<?php echo JHtml::_('form.token'); ?>
 			</fieldset>
 		</form>
 	</div>

--- a/source/administrator/components/com_jedchecker/views/uploads/view.html.php
+++ b/source/administrator/components/com_jedchecker/views/uploads/view.html.php
@@ -28,7 +28,7 @@ class JedcheckerViewUploads extends JViewLegacy
 	public function display($tpl = null)
 	{
 		$this->setToolbar();
-		$this->jsOptions['url'] = JURI::base();
+		$this->jsOptions['url'] = JUri::base();
 		$this->jsOptions['rules'] = $this->getRules();
 		parent::display($tpl);
 	}
@@ -61,19 +61,19 @@ class JedcheckerViewUploads extends JViewLegacy
 	{
 		if ($this->filesExist('archives'))
 		{
-			JToolBarHelper::custom('uploads.unzip', 'folder', 'folder', 'unzip', false);
+			JToolbarHelper::custom('uploads.unzip', 'folder', 'folder', 'unzip', false);
 		}
 
 		if ($this->filesExist('unzipped'))
 		{
-			JToolBarHelper::custom('police.check', 'search', 'search', 'Check', false);
+			JToolbarHelper::custom('police.check', 'search', 'search', 'Check', false);
 		}
 
-		JToolBarHelper::title('JED checker');
+		JToolbarHelper::title('JED checker');
 		
 		if (JFactory::getUser()->authorise('core.admin', 'com_jedchecker'))     
 		{	
-			JToolBarHelper::preferences('com_jedchecker');
+			JToolbarHelper::preferences('com_jedchecker');
 		}
 	}
 


### PR DESCRIPTION
Fixed case in classes and method names to match the definitions.
Fixed the carriage return character on two files, so that each line there appears changed.