### PR TITLE
Jed Checked does not validate itself

### DIFF
--- a/source/administrator/components/com_jedchecker/controllers/uploads.php
+++ b/source/administrator/components/com_jedchecker/controllers/uploads.php
@@ -77,7 +77,7 @@ class JedcheckerControllerUploads extends JControllerlegacy
 			if (!JFile::upload($file['tmp_name'], $file['filepath'], false, true))
 			{
 				// Error in upload
-				JError::raiseWarning(100, JText::_('COM_JEDCHECKER_ERROR_UNABLE_TO_UPLOAD_FILE'));
+				JFactory::getApplication()->enqueueMessage(JText::_('COM_JEDCHECKER_ERROR_UNABLE_TO_UPLOAD_FILE'), 'error');
 
 				return false;
 			}

--- a/source/administrator/components/com_jedchecker/language/en-GB/en-GB.com_jedchecker.ini
+++ b/source/administrator/components/com_jedchecker/language/en-GB/en-GB.com_jedchecker.ini
@@ -2,6 +2,7 @@
 COM_JEDCHECKER_CONFIGURATION="JEDchecker Configuration"
 COM_JEDCHECKER_UPLOAD_FILE="Upload File"
 COM_JEDCHECKER_UPLOAD_WAS_SUCCESSFUL="Upload was successful, next click the unzip button."
+COM_JEDCHECKER_ERROR_UNABLE_TO_UPLOAD_FILE="Upload has failed, ensure that the temporary directory is writable."
 COM_JEDCHECKER_UNZIP_SUCCESS="Unzip was successful, next click the check button."
 COM_JEDCHECKER_UNZIP_FAILED="Unzip failed"
 COM_JEDCHECKER_RESULTS="JED Checker Results"

--- a/source/administrator/components/com_jedchecker/script.php
+++ b/source/administrator/components/com_jedchecker/script.php
@@ -23,8 +23,6 @@ class Com_JedcheckerInstallerScript
 	 *
 	 * @param   string               $type    - the installation type
 	 * @param   JInstallerComponent  $parent  - the parent class
-	 *
-	 * @return bool
 	 */
 	public function preflight($type, $parent)
 	{
@@ -33,12 +31,11 @@ class Com_JedcheckerInstallerScript
 		if (version_compare(PHP_VERSION, '5.3.1', '<'))
 		{
 			$this->loadLanguage();
-			Jerror::raiseWarning(null, JText::sprintf('COM_JEDCHECKER_PHP_VERSION_INCOMPATIBLE', PHP_VERSION, '5.3.6'));
-
-			return false;
+			// Enqueue the error message
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('COM_JEDCHECKER_PHP_VERSION_INCOMPATIBLE', PHP_VERSION, '5.3.6'), 'error');
+			// Stop the execution and return to the installer page
+			JFactory::getApplication()->redirect(JRoute::_('index.php?option=com_installer', false));
 		}
-
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
It makes use of the class JError. Replaced with proper alternatives.
In addition, the string COM_JEDCHECKER_ERROR_UNABLE_TO_UPLOAD_FILE was used but not defined.

To test, try installing this extension on PHP 5.2 (it should refuse and raise an error) and check an extension without the /tmp folder or without the proper write permissions to the /tmp folder (it should raise an upload error).